### PR TITLE
Add -1 to changelog for quilt 3.0

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-kpeoplevcard (0.0+git20150716) vivid; urgency=medium
+kpeoplevcard (0.0+git20150716-1) vivid; urgency=medium
 
   * Initial package
 


### PR DESCRIPTION
In order to be built on debian with quilt 3.0, a -1 is needed at the
end of the version string. Without this, a build results in this error:

dpkg-source: error: can't build with source format '3.0 (quilt)':
non-native package version does not contain a revision